### PR TITLE
Multi season with custom mapping ignores first season

### DIFF
--- a/anilist.py
+++ b/anilist.py
@@ -195,6 +195,9 @@ def match_to_plex(anilist_series: List[AnilistSeries], plex_series_watched: List
 
                 custom_mapping_seasons_anilist_id = matched_id
 
+            if custom_mapping_season_count == 1:
+                custom_mapping_season_count = 0
+
             # If we had custom mappings for multiple seasons with the same ID use
             # cumulative episode count and skip per season processing
             if custom_mapping_season_count > 1:


### PR DESCRIPTION
When a show has more than 1 season in plex and a custom mapping is applied the first season is simply ignored.

`custom_mapping_season_count` is set to `1`:
https://github.com/RickDB/PlexAniSync/blob/3d77958528339ca2d2b7c98f6c0db38a7ce39ddc/anilist.py#L190-L194
`plex_seasons[custom_mapping_season_count:]` starts from `1`, meaning item `0` is never included
https://github.com/RickDB/PlexAniSync/blob/3d77958528339ca2d2b7c98f6c0db38a7ce39ddc/anilist.py#L215-L218

Might have missed some nuance as to why this solution might not be the preferred one. It did solve the issue for the couple of series I had this problem with.
