### PR TITLE
Support multiple duplicate anilist ids in custom mappings

### DIFF
--- a/anilist.py
+++ b/anilist.py
@@ -208,14 +208,6 @@ def match_to_plex(anilist_series: List[AnilistSeries], plex_series_watched: List
                     else:
                         match["watched_episodes"] += plex_season.watched_episodes
 
-                        logger.warning(f"[MAPPING] Duplicate anilist-id found for custom mapping | "
-                                       f"title: {plex_title} | "
-                                       f"anilist id: {matched_id} | "
-                                       f"total watched episodes: {match['watched_episodes']} | "
-                                       f"previous season matches: {match['mapped_seasons']} | "
-                                       f"current season: {plex_season.season_number} |"
-                                       )
-
                     match["total_episodes"] = + plex_season.last_episode
                     match["mapped_seasons"].append(plex_season.season_number)
                     match["duplicate_mappings"] += 1

--- a/anilist.py
+++ b/anilist.py
@@ -198,17 +198,14 @@ def match_to_plex(anilist_series: List[AnilistSeries], plex_series_watched: List
                         anilist_matches.append({
                             "anilist_id": matched_id,
                             "watched_episodes": plex_season.watched_episodes,
-                            "total_episodes": plex_season.last_episode,
                             "mapped_seasons": [plex_season.season_number],
                         })
                         continue
                     # For multiple seasons with the same anilist id check how they should be added together
                     elif index > 0 and plex_season.first_episode > plex_seasons[index - 1].last_episode:
                         match["watched_episodes"] = plex_season.watched_episodes
-                        match["total_episodes"] = plex_seasons[index - 1].last_episode + plex_season.last_episode
                     else:
                         match["watched_episodes"] += plex_season.watched_episodes
-                        match["total_episodes"] += plex_season.last_episode
 
                     match["mapped_seasons"].append(plex_season.season_number)
 

--- a/anilist.py
+++ b/anilist.py
@@ -203,7 +203,7 @@ def match_to_plex(anilist_series: List[AnilistSeries], plex_series_watched: List
                         })
                         continue
                     # For multiple seasons with the same anilist id check how they should be added together
-                    elif (index != 0 and plex_season.first_episode > plex_seasons[index - 1].last_episode):
+                    elif index > 0 and plex_season.first_episode > plex_seasons[index - 1].last_episode:
                         match["watched_episodes"] = plex_season.watched_episodes
                     else:
                         match["watched_episodes"] += plex_season.watched_episodes

--- a/anilist.py
+++ b/anilist.py
@@ -194,35 +194,30 @@ def match_to_plex(anilist_series: List[AnilistSeries], plex_series_watched: List
                     )
 
                     if not match:
+                        # Create first match dict for this anilist id
                         anilist_matches.append({
                             "anilist_id": matched_id,
                             "watched_episodes": plex_season.watched_episodes,
                             "total_episodes": plex_season.last_episode,
                             "mapped_seasons": [plex_season.season_number],
-                            "duplicate_mappings": 0,
                         })
                         continue
                     # For multiple seasons with the same anilist id check how they should be added together
                     elif index > 0 and plex_season.first_episode > plex_seasons[index - 1].last_episode:
                         match["watched_episodes"] = plex_season.watched_episodes
+                        match["total_episodes"] = plex_seasons[index - 1].last_episode + plex_season.last_episode
                     else:
                         match["watched_episodes"] += plex_season.watched_episodes
+                        match["total_episodes"] += plex_season.last_episode
 
-                    match["total_episodes"] = + plex_season.last_episode
                     match["mapped_seasons"].append(plex_season.season_number)
-                    match["duplicate_mappings"] += 1
 
             for match in anilist_matches:
                 logger.info(
                     "[MAPPING] Custom Mapping of Title found | "
                     f"title: {plex_title} | anilist id: {match['anilist_id']} | "
                     f"total watched episodes: {match['watched_episodes']} | "
-                    f"seasons mapped: {match['mapped_seasons']} | "
                 )
-                # If we had custom mappings for multiple seasons with the same ID use
-                # cumulative episode count and skip per season processing
-                if match["duplicate_mappings"] == 0:
-                    continue
 
                 add_or_update_show_by_id(
                     anilist_series, plex_title,

--- a/anilist.py
+++ b/anilist.py
@@ -198,7 +198,7 @@ def match_to_plex(anilist_series: List[AnilistSeries], plex_series_watched: List
                         # Create first match dict for this anilist id
                         anilist_matches.append({
                             "anilist_id": matched_id,
-                            "watched_episodes": mapped_start + plex_season.watched_episodes,
+                            "watched_episodes": plex_season.watched_episodes - mapped_start + 1,
                             "total_episodes": plex_season.last_episode,
                             "mapped_seasons": [plex_season.season_number],
                         })

--- a/anilist.py
+++ b/anilist.py
@@ -205,7 +205,7 @@ def match_to_plex(anilist_series: List[AnilistSeries], plex_series_watched: List
                         continue
                     # For multiple seasons with the same id
                     # If the start of this season has been mapped use that.
-                    if mapped_start > 1:
+                    if mapped_start != 1:
                         match["watched_episodes"] = (plex_season.watched_episodes - mapped_start + 1)
                     else:
                         match["watched_episodes"] += plex_season.watched_episodes

--- a/custom_mappings.py
+++ b/custom_mappings.py
@@ -146,7 +146,7 @@ def add_mappings(custom_mappings, mapping_location, file_mappings):
         for file_season in file_entry['seasons']:
             season = file_season['season']
             anilist_id = file_season['anilist-id']
-            start = file_season.get('start', 1)
+            start = file_season.get('start', 0)
             logger.info(
                 f"[MAPPING] Adding custom mapping from {mapping_location} "
                 f"| title: {series_title} | season: {season} | anilist id: {anilist_id}"

--- a/custom_mappings.py
+++ b/custom_mappings.py
@@ -146,7 +146,7 @@ def add_mappings(custom_mappings, mapping_location, file_mappings):
         for file_season in file_entry['seasons']:
             season = file_season['season']
             anilist_id = file_season['anilist-id']
-            start = file_season.get('start', 0)
+            start = file_season.get('start', 1)
             logger.info(
                 f"[MAPPING] Adding custom mapping from {mapping_location} "
                 f"| title: {series_title} | season: {season} | anilist id: {anilist_id}"


### PR DESCRIPTION
Issue: [144](https://github.com/RickDB/PlexAniSync/issues/144)

This allows the usage of multiple anilist-ids duplicates with multiple seasons. By allowing this, long series such as fairy tail can have a set of plex seasons match one anilist item and another set match another anilist item.

This configuration is now supported:
```
seasons:
      - season: 1
        anilist-id: 6702
      - season: 2
        anilist-id: 6702
      - season: 3
        anilist-id: 20626
      - season: 4
        anilist-id: 20626
```



Testing data:
![imagem](https://user-images.githubusercontent.com/30257011/208968163-27ccfd88-c3bd-44a1-94f7-cc0f74f16151.png)


Results in Anilist:
![imagem](https://user-images.githubusercontent.com/30257011/208968108-1fc18eb9-03c7-40b6-82ef-298a232a8ee5.png)

