### PR TITLE
fix: catch type error if rating is None

### DIFF
--- a/plexanisync/plexmodule.py
+++ b/plexanisync/plexmodule.py
@@ -249,7 +249,7 @@ class PlexModule:
                         #    show.originalTitle = show.title
                         show.originalTitle = show.title
 
-                        rating = int(show.userRating * 10)
+                        rating = int(show.userRating or 0) * 10
                         watched_show = PlexWatchedSeries(
                             show.title.strip(),
                             show.titleSort.strip(),


### PR DESCRIPTION
Tested in ipython3:

```
In [3]: int(None or 0) * 10
Out[3]: 0

In [4]: int(2 or 0) * 10
Out[4]: 20
```

Fixes #191 